### PR TITLE
updated for actual raspbian version

### DIFF
--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Crosstool-NG Configuration
+# crosstool-NG crosstool-ng-1.23.0-236-g42429d91 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_wget=y
@@ -24,7 +24,7 @@ CT_MODULES=y
 #
 # crosstool-NG behavior
 #
-CT_OBSOLETE=y
+# CT_OBSOLETE is not set
 CT_EXPERIMENTAL=y
 # CT_ALLOW_BUILD_AS_ROOT is not set
 # CT_DEBUG_CT is not set
@@ -36,7 +36,7 @@ CT_LOCAL_TARBALLS_DIR="/home/doc/raspberry-pi/cross/tarballs"
 CT_SAVE_TARBALLS=y
 CT_WORK_DIR="${CT_TOP_DIR}/.build"
 CT_BUILD_TOP_DIR="${CT_WORK_DIR}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
-CT_PREFIX_DIR="/home/doc/raspberry-pi/cross/arm-raspbian-linux-gnueabihf/"
+CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
 # CT_PREFIX_DIR_RO is not set
@@ -55,6 +55,13 @@ CT_CONNECT_TIMEOUT=10
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
+CT_VERIFY_DOWNLOAD_DIGEST=y
+CT_VERIFY_DOWNLOAD_DIGEST_SHA512=y
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA256 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA1 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_MD5 is not set
+CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
+# CT_VERIFY_DOWNLOAD_SIGNATURE is not set
 
 #
 # Extracting
@@ -66,8 +73,6 @@ CT_PATCH_BUNDLED=y
 # CT_PATCH_LOCAL is not set
 # CT_PATCH_BUNDLED_LOCAL is not set
 # CT_PATCH_LOCAL_BUNDLED is not set
-# CT_PATCH_BUNDLED_FALLBACK_LOCAL is not set
-# CT_PATCH_LOCAL_FALLBACK_BUNDLED is not set
 # CT_PATCH_NONE is not set
 CT_PATCH_ORDER="bundled"
 
@@ -105,46 +110,46 @@ CT_LOG_FILE_COMPRESS=y
 #
 # Target options
 #
+# CT_ARCH_ALPHA is not set
+CT_ARCH_ARM=y
+# CT_ARCH_AVR is not set
+# CT_ARCH_M68K is not set
+# CT_ARCH_MICROBLAZE is not set
+# CT_ARCH_MIPS is not set
+# CT_ARCH_MSP430 is not set
+# CT_ARCH_NIOS2 is not set
+# CT_ARCH_POWERPC is not set
+# CT_ARCH_S390 is not set
+# CT_ARCH_SH is not set
+# CT_ARCH_SPARC is not set
+# CT_ARCH_X86 is not set
+# CT_ARCH_XTENSA is not set
 CT_ARCH="arm"
-# CT_ARCH_alpha is not set
-CT_ARCH_arm=y
-# CT_ARCH_avr is not set
-# CT_ARCH_m68k is not set
-# CT_ARCH_microblaze is not set
-# CT_ARCH_mips is not set
-# CT_ARCH_nios2 is not set
-# CT_ARCH_powerpc is not set
-# CT_ARCH_s390 is not set
-# CT_ARCH_sh is not set
-# CT_ARCH_sparc is not set
-# CT_ARCH_x86 is not set
-# CT_ARCH_xtensa is not set
-CT_ARCH_alpha_AVAILABLE=y
-CT_ARCH_arm_AVAILABLE=y
-CT_ARCH_avr_AVAILABLE=y
-CT_ARCH_m68k_AVAILABLE=y
-CT_ARCH_microblaze_AVAILABLE=y
-CT_ARCH_mips_AVAILABLE=y
-CT_ARCH_nios2_AVAILABLE=y
-CT_ARCH_powerpc_AVAILABLE=y
-CT_ARCH_s390_AVAILABLE=y
-CT_ARCH_sh_AVAILABLE=y
-CT_ARCH_sparc_AVAILABLE=y
-CT_ARCH_x86_AVAILABLE=y
-CT_ARCH_xtensa_AVAILABLE=y
-CT_ARCH_SUFFIX="v6"
+CT_ARCH_CPU=""
+CT_ARCH_TUNE="arm1176jzf-s"
+CT_ARCH_ARM_MODE="arm"
+CT_ARCH_ARM_MODE_ARM=y
+# CT_ARCH_ARM_MODE_THUMB is not set
+CT_ARCH_ARM_INTERWORKING=y
+CT_ARCH_ARM_EABI_FORCE=y
+CT_ARCH_ARM_EABI=y
+CT_ARCH_ARM_TUPLE_USE_EABIHF=y
+CT_ARCH_SUFFIX=""
 
 #
 # Generic target options
 #
 CT_MULTILIB=y
+CT_DEMULTILIB=y
 CT_ARCH_SUPPORTS_BOTH_MMU=y
 CT_ARCH_DEFAULT_HAS_MMU=y
 CT_ARCH_USE_MMU=y
-CT_ARCH_SUPPORTS_BOTH_ENDIAN=y
+CT_ARCH_SUPPORTS_EITHER_ENDIAN=y
 CT_ARCH_DEFAULT_LE=y
 # CT_ARCH_BE is not set
 CT_ARCH_LE=y
+# CT_ARCH_BE_LE is not set
+# CT_ARCH_LE_BE is not set
 CT_ARCH_ENDIAN="little"
 CT_ARCH_SUPPORTS_32=y
 CT_ARCH_SUPPORTS_64=y
@@ -164,8 +169,6 @@ CT_ARCH_SUPPORTS_WITH_FPU=y
 CT_ARCH_SUPPORTS_SOFTFP=y
 CT_ARCH_EXCLUSIVE_WITH_CPU=y
 CT_ARCH_ARCH="armv6"
-CT_ARCH_CPU=""
-CT_ARCH_TUNE=""
 CT_ARCH_FPU="vfp"
 # CT_ARCH_FLOAT_AUTO is not set
 CT_ARCH_FLOAT_HW=y
@@ -176,28 +179,21 @@ CT_TARGET_LDFLAGS=""
 CT_ARCH_FLOAT="hard"
 
 #
-# arm other options
-#
-CT_ARCH_ARM_MODE="arm"
-CT_ARCH_ARM_MODE_ARM=y
-# CT_ARCH_ARM_MODE_THUMB is not set
-CT_ARCH_ARM_INTERWORKING=y
-CT_ARCH_ARM_EABI=y
-CT_ARCH_ARM_TUPLE_USE_EABIHF=y
-
-#
 # Toolchain options
 #
 
 #
 # General toolchain options
 #
+CT_FORCE_SYSROOT=y
 CT_USE_SYSROOT=y
 CT_SYSROOT_NAME="sysroot"
 CT_SYSROOT_DIR_PREFIX=""
 CT_WANTS_STATIC_LINK=y
-# CT_STATIC_TOOLCHAIN is not set
-CT_TOOLCHAIN_PKGVERSION="Raspbian-cross 4.9.4"
+CT_WANTS_STATIC_LINK_CXX=y
+CT_STATIC_TOOLCHAIN=y
+CT_SHOW_CT_VERSION=y
+CT_TOOLCHAIN_PKGVERSION=""
 CT_TOOLCHAIN_BUGURL=""
 
 #
@@ -205,7 +201,7 @@ CT_TOOLCHAIN_BUGURL=""
 #
 CT_TARGET_VENDOR="raspbian"
 CT_TARGET_ALIAS_SED_EXPR=""
-CT_TARGET_ALIAS=""
+CT_TARGET_ALIAS="arm-linux-gnueabihf"
 
 #
 # Toolchain type
@@ -232,62 +228,46 @@ CT_BUILD_SUFFIX=""
 # Operating System
 #
 CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+# CT_KERNEL_BARE_METAL is not set
+CT_KERNEL_LINUX=y
 CT_KERNEL="linux"
-CT_KERNEL_VERSION="4.1.38"
-# CT_KERNEL_bare_metal is not set
-CT_KERNEL_linux=y
-CT_KERNEL_bare_metal_AVAILABLE=y
-CT_KERNEL_linux_AVAILABLE=y
-# CT_KERNEL_LINUX_CUSTOM is not set
-# CT_KERNEL_V_4_10 is not set
-# CT_KERNEL_V_4_9 is not set
-# CT_KERNEL_V_4_8 is not set
-# CT_KERNEL_V_4_7 is not set
-# CT_KERNEL_V_4_6 is not set
-# CT_KERNEL_V_4_5 is not set
-# CT_KERNEL_V_4_4 is not set
-# CT_KERNEL_V_4_3 is not set
-# CT_KERNEL_V_4_2 is not set
-CT_KERNEL_V_4_1=y
-# CT_KERNEL_V_4_0 is not set
-# CT_KERNEL_V_3_19 is not set
-# CT_KERNEL_V_3_18 is not set
-# CT_KERNEL_V_3_17 is not set
-# CT_KERNEL_V_3_16 is not set
-# CT_KERNEL_V_3_15 is not set
-# CT_KERNEL_V_3_14 is not set
-# CT_KERNEL_V_3_13 is not set
-# CT_KERNEL_V_3_12 is not set
-# CT_KERNEL_V_3_11 is not set
-# CT_KERNEL_V_3_10 is not set
-# CT_KERNEL_V_3_9 is not set
-# CT_KERNEL_V_3_8 is not set
-# CT_KERNEL_V_3_7 is not set
-# CT_KERNEL_V_3_6 is not set
-# CT_KERNEL_V_3_5 is not set
-# CT_KERNEL_V_3_4 is not set
-# CT_KERNEL_V_3_3 is not set
-# CT_KERNEL_V_3_2 is not set
-# CT_KERNEL_V_3_1 is not set
-# CT_KERNEL_V_3_0 is not set
-# CT_KERNEL_V_2_6_39 is not set
-# CT_KERNEL_V_2_6_38 is not set
-# CT_KERNEL_V_2_6_37 is not set
-# CT_KERNEL_V_2_6_36 is not set
-# CT_KERNEL_V_2_6_35 is not set
-# CT_KERNEL_V_2_6_34 is not set
-# CT_KERNEL_V_2_6_33 is not set
-# CT_KERNEL_V_2_6_32 is not set
-CT_KERNEL_windows_AVAILABLE=y
-
-#
-# Common kernel options
-#
-CT_SHARED_LIBS=y
-
-#
-# linux other options
-#
+CT_LINUX_DIR_NAME="linux"
+CT_LINUX_PKG_NAME="linux"
+# CT_LINUX_SRC_RELEASE is not set
+CT_LINUX_SRC_DEVEL=y
+CT_LINUX_DEVEL_VCS_git=y
+# CT_LINUX_DEVEL_VCS_svn is not set
+# CT_LINUX_DEVEL_VCS_hg is not set
+# CT_LINUX_DEVEL_VCS_cvs is not set
+CT_LINUX_DEVEL_VCS="git"
+CT_LINUX_DEVEL_URL="https://github.com/raspberrypi/linux.git"
+CT_LINUX_DEVEL_BRANCH="rpi-4.9.y"
+CT_LINUX_DEVEL_REVISION=""
+CT_LINUX_DEVEL_SUBDIR=""
+CT_LINUX_DEVEL_BOOTSTRAP=""
+# CT_LINUX_SRC_CUSTOM is not set
+# CT_LINUX_VERY_NEW is not set
+# CT_LINUX_V_4_13 is not set
+# CT_LINUX_V_4_12 is not set
+# CT_LINUX_V_4_11 is not set
+# CT_LINUX_V_4_10 is not set
+CT_LINUX_V_4_9=y
+# CT_LINUX_V_4_4 is not set
+# CT_LINUX_V_4_1 is not set
+# CT_LINUX_V_3_16 is not set
+# CT_LINUX_V_3_13 is not set
+# CT_LINUX_V_3_12 is not set
+# CT_LINUX_V_3_10 is not set
+# CT_LINUX_V_3_4 is not set
+# CT_LINUX_V_3_2 is not set
+CT_LINUX_VERSION="4.9.52"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
+CT_LINUX_3_2_or_later=y
+CT_LINUX_REQUIRE_3_2_or_later=y
 CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
 # CT_KERNEL_LINUX_VERBOSITY_2 is not set
@@ -295,86 +275,109 @@ CT_KERNEL_LINUX_VERBOSE_LEVEL=0
 CT_KERNEL_LINUX_INSTALL_CHECK=y
 
 #
+# Common kernel options
+#
+CT_SHARED_LIBS=y
+
+#
 # Binary utilities
 #
 CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS_BINUTILS=y
 CT_BINUTILS="binutils"
-CT_BINUTILS_binutils=y
 
 #
 # GNU binutils
 #
-# CT_BINUTILS_CUSTOM is not set
-CT_BINUTILS_VERSION="2.28"
-# CT_BINUTILS_SHOW_LINARO is not set
-CT_BINUTILS_V_2_28=y
+CT_BINUTILS_DIR_NAME="binutils"
+CT_BINUTILS_USE_GNU=y
+CT_BINUTILS_USE="BINUTILS"
+CT_BINUTILS_PKG_NAME="binutils"
+CT_BINUTILS_SRC_RELEASE=y
+# CT_BINUTILS_SRC_DEVEL is not set
+# CT_BINUTILS_SRC_CUSTOM is not set
+# CT_BINUTILS_V_2_29_1 is not set
+CT_BINUTILS_V_2_28_1=y
 # CT_BINUTILS_V_2_27 is not set
-# CT_BINUTILS_V_2_26 is not set
-# CT_BINUTILS_V_2_25_1 is not set
-# CT_BINUTILS_V_2_24 is not set
-# CT_BINUTILS_V_2_23_2 is not set
-CT_BINUTILS_2_27_or_later=y
-CT_BINUTILS_2_26_or_later=y
-CT_BINUTILS_2_25_1_or_later=y
+# CT_BINUTILS_V_2_26_1 is not set
+CT_BINUTILS_VERSION="2.28.1"
+CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
+CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
 CT_BINUTILS_2_25_or_later=y
-CT_BINUTILS_2_24_or_later=y
-CT_BINUTILS_2_23_2_or_later=y
+CT_BINUTILS_2_23_or_later=y
 CT_BINUTILS_HAS_HASH_STYLE=y
 CT_BINUTILS_HAS_GOLD=y
-CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
-CT_BINUTILS_GOLD_SUPPORT=y
 CT_BINUTILS_HAS_PLUGINS=y
 CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
 CT_BINUTILS_FORCE_LD_BFD_DEFAULT=y
 CT_BINUTILS_LINKER_LD=y
-# CT_BINUTILS_LINKER_LD_GOLD is not set
-# CT_BINUTILS_LINKER_GOLD_LD is not set
 CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
-CT_BINUTILS_PLUGINS=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
-# CT_BINUTILS_FOR_TARGET is not set
-
-#
-# binutils other options
-#
+CT_BINUTILS_FOR_TARGET=y
+CT_BINUTILS_FOR_TARGET_IBERTY=y
+CT_BINUTILS_FOR_TARGET_BFD=y
 
 #
 # C-library
 #
+# CT_LIBC_BIONIC is not set
+CT_LIBC_GLIBC=y
+# CT_LIBC_MUSL is not set
+# CT_LIBC_UCLIBC is not set
 CT_LIBC="glibc"
-CT_LIBC_VERSION="2.25"
-CT_LIBC_glibc=y
-# CT_LIBC_musl is not set
-# CT_LIBC_uClibc is not set
-CT_LIBC_avr_libc_AVAILABLE=y
-CT_LIBC_glibc_AVAILABLE=y
 CT_THREADS="nptl"
-# CT_LIBC_GLIBC_CUSTOM is not set
-# CT_CC_GLIBC_SHOW_LINARO is not set
-CT_LIBC_GLIBC_V_2_25=y
-# CT_LIBC_GLIBC_V_2_24 is not set
-# CT_LIBC_GLIBC_V_2_23 is not set
-# CT_LIBC_GLIBC_V_2_22 is not set
-# CT_LIBC_GLIBC_V_2_21 is not set
-# CT_LIBC_GLIBC_V_2_20 is not set
-# CT_LIBC_GLIBC_V_2_19 is not set
-# CT_LIBC_GLIBC_V_2_18 is not set
-# CT_LIBC_GLIBC_V_2_17 is not set
-# CT_LIBC_GLIBC_V_2_16_0 is not set
-# CT_LIBC_GLIBC_V_2_15 is not set
-# CT_LIBC_GLIBC_V_2_14_1 is not set
-# CT_LIBC_GLIBC_V_2_14 is not set
-# CT_LIBC_GLIBC_V_2_13 is not set
-# CT_LIBC_GLIBC_V_2_12_1 is not set
-CT_LIBC_GLIBC_2_23_or_later=y
-CT_LIBC_GLIBC_2_20_or_later=y
-CT_LIBC_GLIBC_2_17_or_later=y
-CT_LIBC_mingw_AVAILABLE=y
-CT_LIBC_musl_AVAILABLE=y
-CT_LIBC_newlib_AVAILABLE=y
-CT_LIBC_none_AVAILABLE=y
-CT_LIBC_uClibc_AVAILABLE=y
+CT_GLIBC_DIR_NAME="glibc"
+CT_GLIBC_USE_GNU=y
+CT_GLIBC_USE="GLIBC"
+CT_GLIBC_PKG_NAME="glibc"
+CT_GLIBC_SRC_RELEASE=y
+# CT_GLIBC_SRC_DEVEL is not set
+# CT_GLIBC_SRC_CUSTOM is not set
+# CT_GLIBC_V_2_26 is not set
+# CT_GLIBC_V_2_25 is not set
+CT_GLIBC_V_2_24=y
+# CT_GLIBC_V_2_23 is not set
+# CT_GLIBC_V_2_19 is not set
+# CT_GLIBC_V_2_17 is not set
+# CT_GLIBC_V_2_12_1 is not set
+CT_GLIBC_VERSION="2.24"
+CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
+CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
+CT_GLIBC_2_26_or_older=y
+CT_GLIBC_2_24_or_later=y
+CT_GLIBC_2_24_or_older=y
+CT_GLIBC_2_23_or_later=y
+CT_GLIBC_2_20_or_later=y
+CT_GLIBC_2_17_or_later=y
+CT_GLIBC_2_14_or_later=y
+CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
+CT_GLIBC_DEP_BINUTILS=y
+CT_GLIBC_DEP_GCC=y
+CT_GLIBC_HAS_LIBIDN_ADDON=y
+# CT_GLIBC_USE_LIBIDN_ADDON is not set
+CT_GLIBC_NO_SPARC_V8=y
+CT_GLIBC_HAS_OBSOLETE_RPC=y
+CT_GLIBC_EXTRA_CONFIG_ARRAY=""
+CT_GLIBC_CONFIGPARMS=""
+CT_GLIBC_EXTRA_CFLAGS=""
+CT_GLIBC_ENABLE_OBSOLETE_RPC=y
+# CT_GLIBC_ENABLE_FORTIFIED_BUILD is not set
+# CT_GLIBC_DISABLE_VERSIONING is not set
+CT_GLIBC_OLDEST_ABI=""
+CT_GLIBC_FORCE_UNWIND=y
+# CT_GLIBC_LOCALES is not set
+CT_GLIBC_KERNEL_VERSION_NONE=y
+# CT_GLIBC_KERNEL_VERSION_AS_HEADERS is not set
+# CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
+CT_GLIBC_MIN_KERNEL=""
 CT_LIBC_SUPPORT_THREADS_ANY=y
 CT_LIBC_SUPPORT_THREADS_NATIVE=y
 
@@ -382,73 +385,70 @@ CT_LIBC_SUPPORT_THREADS_NATIVE=y
 # Common C library options
 #
 CT_THREADS_NATIVE=y
+# CT_CREATE_LDSO_CONF is not set
 CT_LIBC_XLDD=y
-
-#
-# glibc other options
-#
-CT_LIBC_GLIBC_NEEDS_PORTS=y
-CT_LIBC_glibc_family=y
-CT_LIBC_GLIBC_EXTRA_CONFIG_ARRAY="--enable-add-ons"
-CT_LIBC_GLIBC_CONFIGPARMS=""
-CT_LIBC_GLIBC_EXTRA_CFLAGS=""
-# CT_LIBC_ENABLE_FORTIFIED_BUILD is not set
-# CT_LIBC_DISABLE_VERSIONING is not set
-CT_LIBC_OLDEST_ABI="2.19"
-CT_LIBC_GLIBC_FORCE_UNWIND=y
-CT_LIBC_ADDONS_LIST=""
-# CT_LIBC_LOCALES is not set
-# CT_LIBC_GLIBC_KERNEL_VERSION_NONE is not set
-# CT_LIBC_GLIBC_KERNEL_VERSION_AS_HEADERS is not set
-CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN=y
-CT_LIBC_GLIBC_MIN_KERNEL_VERSION="2.6.32"
-CT_LIBC_GLIBC_MIN_KERNEL="2.6.32"
 
 #
 # C compiler
 #
-CT_CC="gcc"
 CT_CC_CORE_PASSES_NEEDED=y
 CT_CC_CORE_PASS_1_NEEDED=y
 CT_CC_CORE_PASS_2_NEEDED=y
-CT_CC_gcc=y
-# CT_CC_GCC_CUSTOM is not set
-CT_CC_GCC_VERSION="4.9.4"
-CT_CC_GCC_SHOW_LINARO=y
-# CT_CC_GCC_V_linaro_6_3 is not set
-# CT_CC_GCC_V_6_3_0 is not set
-# CT_CC_GCC_V_linaro_5_4 is not set
-# CT_CC_GCC_V_5_4_0 is not set
-# CT_CC_GCC_V_linaro_4_9 is not set
-CT_CC_GCC_V_4_9_4=y
-# CT_CC_GCC_V_linaro_4_8 is not set
-# CT_CC_GCC_V_4_8_5 is not set
-CT_CC_GCC_4_8_or_later=y
-CT_CC_GCC_4_9=y
-CT_CC_GCC_4_9_or_later=y
-CT_CC_GCC_ENABLE_PLUGINS=y
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_JAVA=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+CT_CC_GCC=y
+CT_CC="gcc"
+CT_GCC_DIR_NAME="gcc"
+CT_GCC_USE_GNU=y
+# CT_GCC_USE_LINARO is not set
+CT_GCC_USE="GCC"
+CT_GCC_PKG_NAME="gcc"
+CT_GCC_SRC_RELEASE=y
+# CT_GCC_SRC_DEVEL is not set
+# CT_GCC_SRC_CUSTOM is not set
+# CT_GCC_V_7_2_0 is not set
+CT_GCC_V_6_4_0=y
+# CT_GCC_V_5_4_0 is not set
+# CT_GCC_V_4_9_4 is not set
+CT_GCC_VERSION="6.4.0"
+CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
+CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_7_or_older=y
+CT_GCC_6_or_later=y
+CT_GCC_5_or_later=y
+CT_GCC_4_9_2_or_later=y
+CT_GCC_4_9_or_later=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
 CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--with-arch=armv6 --with-float=hard --with-fpu=vfp"
 CT_CC_GCC_EXTRA_CONFIG_ARRAY="--with-arch=armv6 --with-float=hard --with-fpu=vfp --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-version-specific-runtime-libs"
 CT_CC_GCC_MULTILIB_LIST=""
 CT_CC_GCC_STATIC_LIBSTDCXX=y
-CT_CC_GCC_SYSTEM_ZLIB=y
+# CT_CC_GCC_SYSTEM_ZLIB is not set
 CT_CC_GCC_CONFIG_TLS=m
 
 #
 # Optimisation features
 #
 CT_CC_GCC_USE_GRAPHITE=y
-CT_CC_GCC_USE_LTO=y
 
 #
 # Settings for libraries running on target
 #
 # CT_CC_GCC_ENABLE_TARGET_OPTSPACE is not set
-# CT_CC_GCC_LIBMUDFLAP is not set
+CT_CC_GCC_LIBMUDFLAP=y
 CT_CC_GCC_LIBGOMP=y
 CT_CC_GCC_LIBSSP=y
-# CT_CC_GCC_LIBQUADMATH is not set
+CT_CC_GCC_LIBQUADMATH=y
 CT_CC_GCC_LIBSANITIZER=y
 
 #
@@ -456,9 +456,9 @@ CT_CC_GCC_LIBSANITIZER=y
 #
 CT_CC_CXA_ATEXIT=y
 # CT_CC_GCC_DISABLE_PCH is not set
-# CT_CC_GCC_SJLJ_EXCEPTIONS is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m
-CT_CC_GCC_BUILD_ID=y
+# CT_CC_GCC_BUILD_ID is not set
 CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
 # CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
 # CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
@@ -468,13 +468,6 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 # CT_CC_GCC_DEC_FLOAT_BID is not set
 # CT_CC_GCC_DEC_FLOAT_DPD is not set
 # CT_CC_GCC_DEC_FLOATS_NO is not set
-CT_CC_SUPPORT_CXX=y
-CT_CC_SUPPORT_FORTRAN=y
-CT_CC_SUPPORT_JAVA=y
-CT_CC_SUPPORT_ADA=y
-CT_CC_SUPPORT_OBJC=y
-CT_CC_SUPPORT_OBJCXX=y
-CT_CC_SUPPORT_GOLANG=y
 
 #
 # Additional supported languages:
@@ -491,52 +484,43 @@ CT_CC_LANG_OTHERS=""
 #
 # Debug facilities
 #
-# CT_DEBUG_duma is not set
-CT_DEBUG_gdb=y
-CT_GDB_CROSS=y
-# CT_GDB_CROSS_STATIC is not set
-# CT_GDB_CROSS_SIM is not set
-CT_GDB_CROSS_PYTHON=y
-CT_GDB_CROSS_EXTRA_CONFIG_ARRAY=""
-# CT_GDB_NATIVE is not set
-# CT_GDB_GDBSERVER is not set
-
-#
-# gdb version
-#
-# CT_GDB_CUSTOM is not set
-CT_GDB_VERSION="7.12.1"
-# CT_DEBUG_GDB_SHOW_LINARO is not set
-CT_GDB_V_7_12_1=y
+# CT_DEBUG_DUMA is not set
+CT_DEBUG_GDB=y
+CT_GDB_DIR_NAME="gdb"
+CT_GDB_USE_GNU=y
+CT_GDB_USE="GDB"
+CT_GDB_PKG_NAME="gdb"
+CT_GDB_SRC_RELEASE=y
+# CT_GDB_SRC_DEVEL is not set
+# CT_GDB_SRC_CUSTOM is not set
+CT_GDB_V_8_0=y
+# CT_GDB_V_7_12_1 is not set
 # CT_GDB_V_7_11_1 is not set
-# CT_GDB_V_7_10_1 is not set
-# CT_GDB_V_7_10 is not set
-# CT_GDB_V_7_9_1 is not set
-# CT_GDB_V_7_9 is not set
-# CT_GDB_V_7_8_2 is not set
-# CT_GDB_V_7_8_1 is not set
-# CT_GDB_V_7_8 is not set
-# CT_GDB_V_7_7_1 is not set
-# CT_GDB_V_7_7 is not set
-# CT_GDB_V_7_6_1 is not set
-# CT_GDB_V_7_5_1 is not set
-# CT_GDB_V_7_4_1 is not set
-# CT_GDB_V_7_4 is not set
-# CT_GDB_V_7_3_1 is not set
-# CT_GDB_V_7_3a is not set
-# CT_GDB_V_7_2a is not set
-# CT_GDB_V_7_1a is not set
-# CT_GDB_V_7_0_1a is not set
-# CT_GDB_V_7_0a is not set
-# CT_GDB_V_6_8a is not set
-CT_GDB_7_12_or_later=y
+CT_GDB_VERSION="8.0"
+CT_GDB_MIRRORS="$(CT_Mirrors GNU gdb) $(CT_Mirrors sourceware gdb/releases)"
+CT_GDB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GDB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GDB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GDB_SIGNATURE_FORMAT=""
+CT_GDB_8_0_or_later=y
+CT_GDB_8_0_or_older=y
 CT_GDB_7_2_or_later=y
 CT_GDB_7_0_or_later=y
+CT_GDB_CROSS=y
+CT_GDB_CROSS_STATIC=y
+# CT_GDB_CROSS_SIM is not set
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY=""
+# CT_GDB_NATIVE is not set
+CT_GDB_GDBSERVER=y
+CT_GDB_GDBSERVER_HAS_IPA_LIB=y
+# CT_GDB_GDBSERVER_STATIC is not set
+# CT_GDB_GDBSERVER_STATIC_LIBSTDCXX is not set
+# CT_GDB_GDBSERVER_BUILD_IPA_LIB is not set
 CT_GDB_HAS_PKGVERSION_BUGURL=y
 CT_GDB_HAS_PYTHON=y
 CT_GDB_INSTALL_GDBINIT=y
-# CT_DEBUG_ltrace is not set
-# CT_DEBUG_strace is not set
+# CT_DEBUG_LTRACE is not set
+# CT_DEBUG_STRACE is not set
 
 #
 # Companion libraries
@@ -547,7 +531,6 @@ CT_GETTEXT_NEEDED=y
 CT_GMP_NEEDED=y
 CT_MPFR_NEEDED=y
 CT_ISL_NEEDED=y
-CT_CLOOG_NEEDED=y
 CT_MPC_NEEDED=y
 CT_EXPAT_NEEDED=y
 CT_NCURSES_NEEDED=y
@@ -557,64 +540,148 @@ CT_GETTEXT=y
 CT_GMP=y
 CT_MPFR=y
 CT_ISL=y
-CT_CLOOG=y
 CT_MPC=y
 CT_EXPAT=y
 CT_NCURSES=y
 # CT_ZLIB is not set
+
+#
+# libiconv options
+#
+CT_LIBICONV_DIR_NAME="libiconv"
+CT_LIBICONV_PKG_NAME="libiconv"
+CT_LIBICONV_SRC_RELEASE=y
+# CT_LIBICONV_SRC_DEVEL is not set
+# CT_LIBICONV_SRC_CUSTOM is not set
 CT_LIBICONV_V_1_15=y
-# CT_LIBICONV_V_1_14 is not set
 CT_LIBICONV_VERSION="1.15"
+CT_LIBICONV_MIRRORS="$(CT_Mirrors GNU libiconv)"
+CT_LIBICONV_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_LIBICONV_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_LIBICONV_ARCHIVE_FORMATS=".tar.gz"
+CT_LIBICONV_SIGNATURE_FORMAT="packed/.sig"
+
+#
+# gettext options
+#
+CT_GETTEXT_DIR_NAME="gettext"
+CT_GETTEXT_PKG_NAME="gettext"
+CT_GETTEXT_SRC_RELEASE=y
+# CT_GETTEXT_SRC_DEVEL is not set
+# CT_GETTEXT_SRC_CUSTOM is not set
 CT_GETTEXT_V_0_19_8_1=y
-# CT_GETTEXT_V_0_19_7 is not set
 CT_GETTEXT_VERSION="0.19.8.1"
+CT_GETTEXT_MIRRORS="$(CT_Mirrors GNU gettext)"
+CT_GETTEXT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GETTEXT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GETTEXT_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.gz"
+CT_GETTEXT_SIGNATURE_FORMAT="packed/.sig"
+
+#
+# GMP options
+#
+CT_GMP_DIR_NAME="gmp"
+CT_GMP_PKG_NAME="gmp"
+CT_GMP_SRC_RELEASE=y
+# CT_GMP_SRC_DEVEL is not set
+# CT_GMP_SRC_CUSTOM is not set
 CT_GMP_V_6_1_2=y
-# CT_GMP_V_6_1_0 is not set
-# CT_GMP_V_6_0_0 is not set
-# CT_GMP_V_5_1_3 is not set
-# CT_GMP_V_5_1_1 is not set
-# CT_GMP_V_5_0_2 is not set
-# CT_GMP_V_5_0_1 is not set
-# CT_GMP_V_4_3_2 is not set
-# CT_GMP_V_4_3_1 is not set
-# CT_GMP_V_4_3_0 is not set
-CT_GMP_5_0_2_or_later=y
 CT_GMP_VERSION="6.1.2"
-CT_MPFR_V_3_1_5=y
-# CT_MPFR_V_3_1_3 is not set
-# CT_MPFR_V_3_1_2 is not set
-# CT_MPFR_V_3_1_0 is not set
-# CT_MPFR_V_3_0_1 is not set
-# CT_MPFR_V_3_0_0 is not set
-# CT_MPFR_V_2_4_2 is not set
-# CT_MPFR_V_2_4_1 is not set
-# CT_MPFR_V_2_4_0 is not set
-CT_MPFR_VERSION="3.1.5"
-CT_ISL_V_0_15=y
-# CT_ISL_V_0_14 is not set
-# CT_ISL_V_0_12_2 is not set
-CT_ISL_V_0_15_or_later=y
-CT_ISL_V_0_14_or_later=y
-CT_ISL_V_0_12_or_later=y
-CT_ISL_VERSION="0.15"
-CT_CLOOG_V_0_18_4=y
-CT_CLOOG_VERSION="0.18.4"
-CT_CLOOG_0_18_4_or_later=y
-CT_CLOOG_0_18_or_later=y
+CT_GMP_MIRRORS="https://gmplib.org/download/gmp https://gmplib.org/download/gmp/archive $(CT_Mirrors GNU gmp)"
+CT_GMP_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GMP_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GMP_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2"
+CT_GMP_SIGNATURE_FORMAT="packed/.sig"
+CT_GMP_5_1_or_later=y
+
+#
+# MPFR options
+#
+CT_MPFR_DIR_NAME="mpfr"
+CT_MPFR_PKG_NAME="mpfr"
+CT_MPFR_SRC_RELEASE=y
+# CT_MPFR_SRC_DEVEL is not set
+# CT_MPFR_SRC_CUSTOM is not set
+CT_MPFR_V_3_1_6=y
+CT_MPFR_VERSION="3.1.6"
+CT_MPFR_MIRRORS="http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
+CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
+CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
+
+#
+# ISL options
+#
+CT_ISL_DIR_NAME="isl"
+CT_ISL_PKG_NAME="isl"
+CT_ISL_SRC_RELEASE=y
+# CT_ISL_SRC_DEVEL is not set
+# CT_ISL_SRC_CUSTOM is not set
+CT_ISL_V_0_18=y
+# CT_ISL_V_0_17_1 is not set
+# CT_ISL_V_0_16_1 is not set
+# CT_ISL_V_0_15 is not set
+CT_ISL_VERSION="0.18"
+CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_ISL_SIGNATURE_FORMAT=""
+CT_ISL_0_15_or_later=y
+CT_ISL_0_14_or_later=y
+CT_ISL_REQUIRE_0_14_or_later=y
+CT_ISL_0_13_or_later=y
+CT_ISL_0_12_or_later=y
+CT_ISL_REQUIRE_0_12_or_later=y
+
+#
+# MPC options
+#
+CT_MPC_DIR_NAME="mpc"
+CT_MPC_PKG_NAME="mpc"
+CT_MPC_SRC_RELEASE=y
+# CT_MPC_SRC_DEVEL is not set
+# CT_MPC_SRC_CUSTOM is not set
 CT_MPC_V_1_0_3=y
-# CT_MPC_V_1_0_2 is not set
-# CT_MPC_V_1_0_1 is not set
-# CT_MPC_V_1_0 is not set
-# CT_MPC_V_0_9 is not set
-# CT_MPC_V_0_8_2 is not set
-# CT_MPC_V_0_8_1 is not set
-# CT_MPC_V_0_7 is not set
 CT_MPC_VERSION="1.0.3"
-CT_EXPAT_V_2_2_0=y
-# CT_EXPAT_V_2_1_1 is not set
-CT_EXPAT_VERSION="2.2.0"
+CT_MPC_MIRRORS="http://www.multiprecision.org/mpc/download $(CT_Mirrors GNU mpc)"
+CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPC_ARCHIVE_FORMATS=".tar.gz"
+CT_MPC_SIGNATURE_FORMAT="packed/.sig"
+
+#
+# expat options
+#
+CT_EXPAT_DIR_NAME="expat"
+CT_EXPAT_PKG_NAME="expat"
+CT_EXPAT_SRC_RELEASE=y
+# CT_EXPAT_SRC_DEVEL is not set
+# CT_EXPAT_SRC_CUSTOM is not set
+CT_EXPAT_V_2_2_4=y
+CT_EXPAT_VERSION="2.2.4"
+CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
+CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_EXPAT_ARCHIVE_FORMATS=".tar.bz2"
+CT_EXPAT_SIGNATURE_FORMAT=""
+
+#
+# ncurses options
+#
+CT_NCURSES_DIR_NAME="ncurses"
+CT_NCURSES_PKG_NAME="ncurses"
+CT_NCURSES_SRC_RELEASE=y
+# CT_NCURSES_SRC_DEVEL is not set
+# CT_NCURSES_SRC_CUSTOM is not set
 CT_NCURSES_V_6_0=y
 CT_NCURSES_VERSION="6.0"
+CT_NCURSES_MIRRORS="ftp://invisible-island.net/ncurses $(CT_Mirrors GNU ncurses)"
+CT_NCURSES_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_NCURSES_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_NCURSES_ARCHIVE_FORMATS=".tar.gz"
+CT_NCURSES_SIGNATURE_FORMAT="packed/.sig"
 # CT_NCURSES_NEW_ABI is not set
 CT_NCURSES_HOST_CONFIG_ARGS=""
 CT_NCURSES_HOST_DISABLE_DB=y
@@ -632,11 +699,11 @@ CT_NCURSES_TARGET_FALLBACKS=""
 # Companion tools
 #
 # CT_COMP_TOOLS_FOR_HOST is not set
-# CT_COMP_TOOLS_autoconf is not set
-# CT_COMP_TOOLS_automake is not set
-# CT_COMP_TOOLS_libtool is not set
-# CT_COMP_TOOLS_m4 is not set
-# CT_COMP_TOOLS_make is not set
+# CT_COMP_TOOLS_AUTOCONF is not set
+# CT_COMP_TOOLS_AUTOMAKE is not set
+# CT_COMP_TOOLS_LIBTOOL is not set
+# CT_COMP_TOOLS_M4 is not set
+# CT_COMP_TOOLS_MAKE is not set
 
 #
 # Test suite


### PR DESCRIPTION
Hello. Following your comments on [this thread](https://github.com/raspberrypi/tools/issues/50#issuecomment-287636944). i was FINALLY ABLE to compile actual toolchain version for raspbian stretch, that allows linking to raspberry sysroot.

Wanted to share `.config` for more recent ct-ng version and target raspbian